### PR TITLE
Fix code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/src/modules/language.js
+++ b/src/modules/language.js
@@ -18,6 +18,7 @@ const cleanAndParseJSON = async (filePath) => {
 
 const addMissingKeys = (enData, langData) => {
     for (const key in enData) {
+        if (key === '__proto__' || key === 'constructor') continue;
         if (key.startsWith('_')) {
             langData[key] = enData[key];
         } else if (typeof enData[key] === 'object' && enData[key] !== null) {


### PR DESCRIPTION
Fixes [https://github.com/TsukiyoDevTeam/Nyxia-Rewrite/security/code-scanning/2](https://github.com/TsukiyoDevTeam/Nyxia-Rewrite/security/code-scanning/2)

To fix the problem, we need to ensure that the `addMissingKeys` function does not copy prototype pollution properties like `__proto__` and `constructor`. We can achieve this by adding a check to skip these properties during the recursive copy process.

- Modify the `addMissingKeys` function to include a check that skips the `__proto__` and `constructor` properties.
- This change will be made in the `src/modules/language.js` file.
- No additional methods or imports are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
